### PR TITLE
add permissions on panopto.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
 	"permissions": [
 		"downloads",
 		"activeTab",
-		"https://*.panopto.eu/*"
+		"https://*.panopto.eu/*",
+		"https://*.panopto.com/*"
 	],
 	"content_scripts": [
 		{


### PR DESCRIPTION
Sites in the Americas are on the panopto.com domain, you can of course work around this but it's slightly more convenient in the extension requests access in the first place. Love this, it looks really useful to us!